### PR TITLE
add a saw to output the fn name, line num and file name

### DIFF
--- a/src/saws.jl
+++ b/src/saws.jl
@@ -3,4 +3,20 @@
 
 date_saw(args::Dict) = push!(args, :date, now())
 
+function fn_call_saw(args::Dict)
+    lookup = [ccall(:jl_lookup_code_address,
+                    Any,
+                    (Ptr{Void}, Int32), b, 0) for b in backtrace()]
+
+    filter!(l->!isempty(l) &&
+            !any(symb->symb == l[1],
+                 [:fn_call_saw, :log, :info, :warn, :debug]),lookup)
+    if isempty(lookup)
+        args
+    else
+        # lookup is a tuple
+        push!(args, :lookup, lookup[1])
+    end
+end
+
 # -------

--- a/src/timbertruck.jl
+++ b/src/timbertruck.jl
@@ -79,6 +79,14 @@ function log(truck::LumberjackTruck, l::Dict)
     date_stamp = get(l, :date, nothing)
     record = date_stamp == nothing ? "" : "$date_stamp - "
 
+    lookup = get(l, :lookup, nothing)
+    if !is(lookup,nothing)
+        # lookup is a tuple
+        func , fname, linenum = lookup
+        lookup_str = "$(string(func))@$(basename(string(fname))):$(linenum) - "
+        record = record*lookup_str
+    end
+
     mode = l[:mode]
 
     if (truck.opts[:uppercase])
@@ -86,7 +94,9 @@ function log(truck::LumberjackTruck, l::Dict)
     end
 
     record = string(record, "$(l[:mode]): $(l[:msg])")
+
     delete!(l, :date)
+    delete!(l, :lookup)
     delete!(l, :mode)
     delete!(l, :msg)
 


### PR DESCRIPTION
The saw is disabled by default but outputs as follows:
2014-02-24T18:21:31 UTC - my_func_name@file_name.jl:line_num - info: some message to be logged.

is enabled by calling add_saw(lm, fn_call_saw)
