### PR TITLE
Change dependency on Datetime to Dates

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.2-
 
-Datetime
+Dates
 UUID

--- a/src/Lumberjack.jl
+++ b/src/Lumberjack.jl
@@ -5,7 +5,7 @@ import Base.show, Base.log
 # To avoid warnings, intentionally do not import:
 # Base.error, Base.warn, Base.info
 
-using Datetime
+using Dates
 using UUID
 
 export log,

--- a/src/saws.jl
+++ b/src/saws.jl
@@ -4,10 +4,8 @@
 date_saw(args::Dict) = push!(args, :date, now())
 
 function msec_date_saw(args::Dict)
-    now = Datetime.now()
-    push!(args, :date,
-          join(split(string(now)),
-          "."*string(Datetime.milliseconds(now))*" "))
+    now = now()
+    push!(args, :date, string(now))
 end
 
 function fn_call_saw(args::Dict)


### PR DESCRIPTION
Not sure if this is 100%, because the tests don't pass on my machine before these changes either. The motivation here is that Datetime.jl will be deprecated at some point in favor of the new `Dates` module that is now in Base (and exists as a package `Dates.jl` that mirrors Base for 0.3 compatibility).
