### PR TITLE
Syslog and Stack Trace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Lumberjack.jl
 =============
 
-[![Build Status](https://travis-ci.org/forio/Lumberjack.jl.png?branch=master)](https://travis-ci.org/forio/Lumberjack.jl)
+[![Build Status](https://travis-ci.org/invenia/Lumberjack.jl.png?branch=master)](https://travis-ci.org/invenia/Lumberjack.jl)
 
 
 ## Quick Start
@@ -36,25 +36,52 @@ julia> log("info", "use `log` for user-defined modes, or to be verbose.")
 ### Add and remove `TimberTrucks`
 Logs are brought to different output streams by `TimberTrucks`. To create a truck that will dump logs into a file, simply:
 ```julia
-julia> Lumberjack.add_truck(LumberjackTruck("mylogfile.log"), "my-file-logger")
+julia> add_truck(LumberjackTruck("mylogfile.log"), "my-file-logger")
 ```
 Now there is a truck named "my-file-logger", and it will write all of your logs to `mylogfile.log`. Your logs will still show up in the console, however, because -by default- there is a truck named "console" already hard at work. Remove it by calling:
 ```julia
-julia> Lumberjack.remove_truck("console")
+julia> remove_truck("console")
 ```
 
-### Manage logging modes / levels
-Each timber truck is configured to log messages _above_ a certain level / mode, and by default they will log everything. There are 4 built-in modes: `["debug", "info", "warn", "error"]`. To create a timber truck that will only record warnings and errors, you can:
+### Manage logging modes/levels
+
+#### Defining Modes
+
+Timber trucks and saws can both be configured to work only at/above certain log levels/modes.
+
+There are 4 built-in modes: `["debug", "info", "warn", "error"]`. If you'd like to use logging levels/modes beyond the four default modes, you'll want to tell your lumber mill (Lumberjack's log controller) what order the modes are in. You can do this with a call to `configure`:
+
 ```julia
-julia> Lumberjack.add_truck(LumberjackTruck(STDOUT, "warn"), "dangerous-logger")
+julia> configure(; modes=["debug", "info", "notice", "warn", "error", "crit", "alert", "emerg"])
 ```
 
-Or to configure an existing truck, you can call:
+This way, if you only want a truck to log something at warning-level or above and it sees a "notice" message, the truck will know not to log it.
+
+#### Timber Truck Modes
+
+Each timber truck is configured to log messages _at or above_ a certain level/mode, and by default they will log everything. To create a timber truck that will only record warnings and errors, you can:
+
+```julia
+julia> add_truck(LumberjackTruck(STDOUT, "warn"), "dangerous-logger")
 ```
+
+Or to configure an existing truck, you can call `configure` and specify the truck in question:
+
+```julia
 julia> configure(timber_truck; mode = "warn")
 ```
 
-See [Log Level Example](#log-level-example) below.
+For additional examples, see the [Log Level Example](#log-level-example) below.
+
+#### Saw Modes
+
+When saws are added, they can also be configured such that they are only included for logs at or above a certain level. For example, you may want to include a stack trace for each log that's a warning or above:
+
+```julia
+julia> add_saw(Saw(Lumberjack.stacktrace_saw, "warn"))
+```
+
+For additional examples, see the [Log Level Example](#log-level-example) below.
 
 ### Logging Options
 `Lumberjack.add_truck` provides an optional third `Dict` argument. Possible keys are:
@@ -63,7 +90,7 @@ See [Log Level Example](#log-level-example) below.
 Colors can be added enabled using the following:
 
 ```julia
-Lumberjack.add_truck(LumberjackTruck(STDOUT, nothing, {:is_colorized => true}), "console")
+add_truck(LumberjackTruck(STDOUT, nothing, {:is_colorized => true}), "console")
 ```
 
 ![colors](img/colors.png)
@@ -76,13 +103,13 @@ By default the following colors are used:
 #### colors
 Custom colors/log levels can also be specified:
 ```julia
-Lumberjack.add_truck(LumberjackTruck(STDOUT, nothing, :colors => {"debug" => :black, "info" => :blue, "warn" => :yellow, "error" => :red, "crazy" => :green}), "console")
+add_truck(LumberjackTruck(STDOUT, nothing, :colors => {"debug" => :black, "info" => :blue, "warn" => :yellow, "error" => :red, "crazy" => :green}), "console")
 ```
 
 #### uppercase
 Log levels can be made uppercase (INFO vs info, etc.) with the following option:
 ```julia
-Lumberjack.add_truck(LumberjackTruck(STDOUT, nothing, {:uppercase => true}), "console")
+add_truck(LumberjackTruck(STDOUT, nothing, {:uppercase => true}), "console")
 ```
 
 ## Architecture
@@ -124,10 +151,12 @@ error(lm::LumberMill, msg::String, args::Dict)
 
 ### Saws
 ```julia
-add_saw(lm::LumberMill, saw_fn::Function, index)
+add_saw(lm::LumberMill, saw::Saw, index::Integer)
+add_saw(lm::LumberMill, saw_fn::Function, index::Integer)
 ```
 + `index` is optional and will default to the end of the saw list
 
+Typically when adding a saw you will simply specify the saw function itself, but if you'd like to limit your saw to certain logging levels/modes then you'll want to use the `Lumberjack.Saw` type. See the [Log Level Example](#log-level-example) below.
 
 ```julia
 remove_saw(lm::LumberMill, index)
@@ -167,37 +196,6 @@ configure(lm::LumberMill; modes = ["debug", "info", "warn", "error"])
 
 ## Recipes and Examples
 
-### Log Level Example
-
-```julia
-julia> using Lumberjack
-
-# We already have console output of all modes/log levels via the default console truck.
-
-# Let's add a truck that will ignore debug messages (only outputting warning-level and up).
-julia> add_truck(JsonTruck(STDOUT, "info"), "json-logger")
-Lumberjack.JsonTruck(Base.TTY(open, 0 bytes waiting),"info")
-
-# Let's add another that will only output logs at warning-level and above.
-julia> add_truck(LumberjackTruck(STDOUT, "warn"), "new-logger")
-Lumberjack.LumberjackTruck(Base.TTY(open, 0 bytes waiting),"warn",Dict{Any,Any}(:is_colorized=>false,:uppercase=>false))
-
-# Warnings should show up for all three trucks: json-logger, new-logger, console (default).
-julia> Lumberjack.warn("Message")
-{"date":"2015-11-16T12:09:57","msg":"Message","mode":"warn"}
-2015-11-16T12:09:57 - warn: Message
-2015-11-16T12:09:57 - warn: Message
-
-# Info is less important than a warning, so won't show up for new-logger.
-julia> Lumberjack.info("Something")
-{"date":"2015-11-16T12:10:09","msg":"Something","mode":"info"}
-2015-11-16T12:10:09 - info: Something
-
-# Debug level isn't important enough to log for either json-logger or new-logger.
-julia> Lumberjack.debug("Not very important")
-2015-11-16T12:10:15 - debug: Not very important
-```
-
 ### Including Additional Fields
 
 Additional parameters may be specified in calls to `log` (and `debug`, `info`, `warn`, and `error`) by passing a `Dict` as the final positional argument. This is useful if you'd like to specify values for fields other than `mode` and `msg` that are not provided by saws.
@@ -216,12 +214,61 @@ julia> Lumberjack.warn("Something happened.", Dict{Any, Any}(:id=>"LoggingTest",
 2015-11-16T15:24:54 - warn: Something happened. resolve: "Next steps." id: "LoggingTest" cause: "Needed an example." impact: "None, really."
 ```
 
+### Log Level Example
+
+```julia
+julia> using Lumberjack
+
+# We already have console output of all modes/log levels via the default console truck.
+
+# Define some additional log levels.
+julia> configure(; modes=["debug", "info", "warn", "error", "crit"])
+
+# Let's add a truck that will ignore debug/info messages (only outputting info-level and up).
+julia> add_truck(LumberjackTruck(STDOUT, "info"), "new-logger")
+Lumberjack.LumberjackTruck(Base.TTY(open, 0 bytes waiting),"info",Dict{Any,Any}(:is_colorized=>false,:uppercase=>false))
+
+# Let's add another that will only output logs at warning-level and above.
+julia> add_truck(JsonTruck(STDOUT, "warn"), "json-logger")
+Lumberjack.JsonTruck(Base.TTY(open, 0 bytes waiting),"warn")
+
+# Add the function call saw to each log entry that is error-level or above.
+add_saw(Saw(Lumberjack.fn_call_saw, "error"))
+2-element Array{Lumberjack.Saw,1}:
+ Lumberjack.Saw(Lumberjack.msec_date_saw,nothing)
+ Lumberjack.Saw(Lumberjack.fn_call_saw,"error")
+
+# Crticial messages will show up for all three trucks: json-logger, new-logger, console (default).
+julia> log("crit", "Message")
+{"date":"2015-11-19T11:24:31","lookup":{"name":"eval_user_input","file":"REPL.jl","line":62},"msg":"Message","mode":"crit"}
+2015-11-19T11:24:31 - eval_user_input@REPL.jl:62 - crit: Message
+2015-11-19T11:24:31 - eval_user_input@REPL.jl:62 - crit: Message
+
+# Warning messages also show up for all trucks (but without function call information).
+julia> log("warn", "Message")
+{"date":"2015-11-19T11:24:49","msg":"Message","mode":"warn"}
+2015-11-19T11:24:49 - warn: Message
+2015-11-19T11:24:49 - warn: Message
+
+# Info is less important than a warning, so won't show up for new-logger.
+julia> log("info", "Something")
+2015-11-19T11:25:52 - info: Message
+2015-11-19T11:25:52 - info: Message
+
+# Debug level isn't important enough to log for either json-logger or new-logger.
+julia> log("debug", "Not very important")
+2015-11-19T11:26:16 - debug: Not very important
+```
+
 ### Syslog and Stack Trace Example
 
 Please note that syslog output is only available on systems that have `logger` utility installed. (This should include both Linux and OS X, but typically excludes Windows.)
 
 ```julia
 julia> using Lumberjack
+
+# Configure Lumberjack to recognize all Syslog log levels.
+julia> configure(; modes=["debug", "info", "notice", "warn", "error", "crit", "alert", "emerg"])
 
 # Output to syslog on facility "local0", with tag "julia", and include Julia's process ID.
 julia> syslog_io = Syslog(:local0, "julia", true)
@@ -231,24 +278,22 @@ Lumberjack.Syslog(:local0,"julia",63474)
 julia> add_truck(JsonTruck(syslog_io, "warn"), "syslog-json")
 Lumberjack.JsonTruck(Lumberjack.Syslog(:local0,"julia",63474),"warn")
 
-# Add a stacktrace to each log entry.
-add_saw(Lumberjack.stacktrace_saw)
-2-element Array{Any,1}:
- Lumberjack.msec_date_saw 
- Lumberjack.stacktrace_saw
+# Add a stacktrace to each log entry that is error-level or above.
+add_saw(Saw(Lumberjack.stacktrace_saw, "error"))
+2-element Array{Lumberjack.Saw,1}:
+ Lumberjack.Saw(Lumberjack.msec_date_saw,nothing)
+ Lumberjack.Saw(Lumberjack.stacktrace_saw,"error")
 
-julia> log("crit", "Critical message!")
-julia> log("error", "Error message!")
-julia> log("warn", "Warning message!")
-julia> log("info", "Info message!")
+julia> log("crit", "Error message!")		# Includes stack trace.
+julia> log("warn", "Warning message!")		# No stack trace.
+julia> log("notice", "Notice message!")		# Not logged.
 ```
 
 Run `tail /var/log/system.log` (modifying as needed, depeding on where your system stores its logs) and you should see something like this:
 
 ```
-Nov 16 15:00:03 localhost julia[63474]: {"stacktrace":[{"name":"eval_user_input","file":"REPL.jl","line":62},{"name":"anonymous","file":"REPL.jl","line":92}],"date":"2015-11-16T15:00:03","msg":"Critical message!","mode":"crit"}
-Nov 16 15:00:33 localhost julia[63474]: {"stacktrace":[{"name":"eval_user_input","file":"REPL.jl","line":62},{"name":"anonymous","file":"REPL.jl","line":92}],"date":"2015-11-16T15:00:33","msg":"Error message!","mode":"error"}
-Nov 16 15:00:45 localhost julia[63474]: {"stacktrace":[{"name":"eval_user_input","file":"REPL.jl","line":62},{"name":"anonymous","file":"REPL.jl","line":92}],"date":"2015-11-16T15:00:45","msg":"Warning message!","mode":"warn"}
+Nov 17 15:00:03 localhost julia[63474]: {"stacktrace":[{"name":"eval_user_input","file":"REPL.jl","line":62},{"name":"anonymous","file":"REPL.jl","line":92}],"date":"2015-11-17T15:00:03","msg":"Error message!","mode":"error"}
+Nov 17 15:00:45 localhost julia[63474]: {"date":"2015-11-17T15:00:45","msg":"Warning message!","mode":"warn"}
 ```
 
 The info message is missing because we set our truck to only output logs at warning level and above.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Lumberjack.jl
 =============
 
-[![Build Status](https://travis-ci.org/invenia/Lumberjack.jl.png?branch=master)](https://travis-ci.org/invenia/Lumberjack.jl)
+[![Build Status](https://travis-ci.org/WestleyArgentum/Lumberjack.jl.png?branch=master)](https://travis-ci.org/WestleyArgentum/Lumberjack.jl)
 
 
 ## Quick Start

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 
 JSON
+StackTraces

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,3 @@
-julia 0.3
+julia 0.4
 
-Compat
-UUID # required for Julia 0.3, not used if running with Julia 0.4
 JSON
-Dates

--- a/src/FileRoller.jl
+++ b/src/FileRoller.jl
@@ -3,9 +3,9 @@ import Base.println, Base.flush
 FILE_SIZE = 5000 * 1028
 
 type FileRoller <: IO
-    prefix::@compat AbstractString
-    folder::@compat AbstractString
-    filepath::@compat AbstractString
+    prefix::AbstractString
+    folder::AbstractString
+    filepath::AbstractString
     file::IO
     byteswritten::Int64
 end
@@ -18,7 +18,7 @@ function getsuffix(n::Integer)
     str
 end
 
-function getfile(folder::@compat(AbstractString), prefix::@compat(AbstractString))
+function getfile(folder::AbstractString, prefix::AbstractString)
     i = 1
     getpath(i) = joinpath(folder, "$(prefix).$(getsuffix(i))")
     p = getpath(i)
@@ -33,7 +33,7 @@ FileRoller(prefix) = FileRoller(prefix, pwd(), (getfile(pwd(), prefix))..., 0)
 
 FileRoller(prefix, dir) = FileRoller((getfile(dir, prefix))...)
 
-function println(f::FileRoller, s::@compat AbstractString)
+function println(f::FileRoller, s::AbstractString)
     if f.byteswritten > FILE_SIZE
         gf = getfile(f.folder, f.prefix)
         f.filepath = gf[1]

--- a/src/Lumberjack.jl
+++ b/src/Lumberjack.jl
@@ -2,7 +2,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
 module Lumberjack
 
-import Base.show, Base.log
+import Base.show, Base.log, StackTraces
 
 # To avoid warnings, intentionally do not import:
 # Base.error, Base.warn, Base.info

--- a/src/Lumberjack.jl
+++ b/src/Lumberjack.jl
@@ -17,7 +17,8 @@ export log,
        LumberjackTruck,
        CommonLogTruck,
        JsonTruck,
-       FileRoller
+       FileRoller,
+       Syslog
 
 # -------
 
@@ -25,6 +26,7 @@ include("saws.jl")
 include("timbertruck.jl")
 include("lumbermill.jl")
 include("FileRoller.jl")
+include("Syslog.jl")
 
 # -------
 

--- a/src/Lumberjack.jl
+++ b/src/Lumberjack.jl
@@ -6,12 +6,6 @@ import Base.show, Base.log
 
 # To avoid warnings, intentionally do not import:
 # Base.error, Base.warn, Base.info
-using Compat
-
-# for backwards compatibility with 0.3:
-if VERSION < v"0.4.0-"
-    using Dates, UUID
-end
 
 export log,
        debug, info, warn, error,

--- a/src/Lumberjack.jl
+++ b/src/Lumberjack.jl
@@ -17,6 +17,7 @@ export log,
        LumberjackTruck,
        CommonLogTruck,
        JsonTruck,
+       Saw,
        FileRoller,
        Syslog
 

--- a/src/Syslog.jl
+++ b/src/Syslog.jl
@@ -1,0 +1,52 @@
+import Base.println, Base.flush
+
+# Define valid syslog levels and common aliases.
+SYSLOG_LEVELS = [:emerg, :alert, :crit, :err, :warning, :notice, :info, :debug]
+ALIAS_LEVELS = Dict(:warn=>:warning, :error=>:err, :emergency=>:emerg, :critical=>:crit)
+
+# Define valid syslog facilities (even kern, which isn't accessible from userspace).
+FACILITIES = [
+    :auth, :authpriv, :cron, :daemon, :ftp, :kern, :lpr, :mail, :news, :syslog, :user,
+    :uucp, :local0, :local1, :local2, :local3, :local4, :local5, :local6, :local7, :security
+]
+
+type Syslog <: IO
+    facility::Symbol
+    tag::AbstractString
+    pid::Integer
+
+    function Syslog(facility=:local0, tag="julia", tag_pid::Bool=false)
+        try
+            # Verify that logger is installed.
+            run(`logger -f /dev/null`)
+        catch
+            error("syslog output only available on systems with logger installed")
+        end
+
+        if !(facility in FACILITIES)
+            error("invalid logging facility: $(facility)")
+        end
+
+        # Appends Julia's process ID to the log tag if show_pid is specified.
+        pid = tag_pid ? getpid() : -1
+
+        new(facility, tag, pid)
+    end
+end
+
+function println(log::Syslog, level::Symbol, msg::AbstractString)
+    level = get(ALIAS_LEVELS, level, level)
+    if !(level in SYSLOG_LEVELS)
+        throw(ErrorException("invalid level: $level"))
+    end
+
+    tag = log.tag * (log.pid > -1 ? "[$(log.pid)]" : "")
+    run(`logger -t $(tag) -p $(log.facility).$level $msg`)
+end
+
+function println(log::Syslog, level::AbstractString, msg::AbstractString)
+    println(log, symbol(lowercase(level)), msg)
+end
+
+# Defined just in case somebody decides to call flush, which is totally unnecessary.
+flush(log::Syslog) = log

--- a/src/Syslog.jl
+++ b/src/Syslog.jl
@@ -16,10 +16,8 @@ type Syslog <: IO
     pid::Integer
 
     function Syslog(facility=:local0, tag="julia", tag_pid::Bool=false)
-        try
-            # Verify that logger is installed.
-            run(`logger -f /dev/null`)
-        catch
+        # Verify that logger is installed.
+        if !success(`which logger`)
             error("syslog output only available on systems with logger installed")
         end
 

--- a/src/lumbermill.jl
+++ b/src/lumbermill.jl
@@ -43,7 +43,7 @@ function log(lm::LumberMill, mode::AbstractString, msg::AbstractString, args::Di
             continue
         end
 
-        args = saw.saw_fn(args)
+        args = saw(args)
     end
 
     for (truck_name, truck) in lm.timber_trucks

--- a/src/lumbermill.jl
+++ b/src/lumbermill.jl
@@ -10,7 +10,7 @@ type LumberMill
         # defaults
         configure(lm)
         add_saw(lm, msec_date_saw)
-        add_truck(lm, LumberjackTruck(STDOUT, nothing, @compat Dict{Symbol,Any}(:is_colorized => true)), "console")
+        add_truck(lm, LumberjackTruck(STDOUT, nothing, Dict{Symbol,Any}(:is_colorized => true)), "console")
 
         lm
     end
@@ -32,7 +32,7 @@ end
 configure(; args...) = configure(_lumber_mill; args...)
 
 
-function log(lm::LumberMill, mode::@compat(AbstractString), msg::@compat(AbstractString), args::Dict = Dict())
+function log(lm::LumberMill, mode::AbstractString, msg::AbstractString, args::Dict = Dict())
     args[:mode] = mode
     args[:msg] = msg
 
@@ -41,7 +41,7 @@ function log(lm::LumberMill, mode::@compat(AbstractString), msg::@compat(Abstrac
     end
 
     for (truck_name, truck) in lm.timber_trucks
-        if (in(:_mode, @compat fieldnames(truck))
+        if (in(:_mode, fieldnames(truck))
             && truck._mode != nothing
             && get_mode_index(lm, mode) < get_mode_index(lm, truck._mode))
 
@@ -52,30 +52,30 @@ function log(lm::LumberMill, mode::@compat(AbstractString), msg::@compat(Abstrac
     end
 end
 
-log(mode::@compat(AbstractString), msg::@compat(AbstractString), args::Dict = Dict()) = log(_lumber_mill, mode, msg, args)
+log(mode::AbstractString, msg::AbstractString, args::Dict = Dict()) = log(_lumber_mill, mode, msg, args)
 
-log(mode::@compat(AbstractString), args::Dict = Dict()) = log(_lumber_mill, mode, "", args)
-
-
-debug(lm::LumberMill, msg::@compat(AbstractString), args::Dict = Dict()) = log(lm, "debug", msg, args)
-
-debug(msg::@compat(AbstractString), args::Dict) = debug(_lumber_mill, msg, args)
-
-debug(msg::@compat(AbstractString)...) = debug(_lumber_mill, string(msg...))
+log(mode::AbstractString, args::Dict = Dict()) = log(_lumber_mill, mode, "", args)
 
 
-info(lm::LumberMill, msg::@compat(AbstractString), args::Dict = Dict()) = log(lm, "info", msg, args)
+debug(lm::LumberMill, msg::AbstractString, args::Dict = Dict()) = log(lm, "debug", msg, args)
 
-info(msg::@compat(AbstractString), args::Dict) = info(_lumber_mill, msg, args)
+debug(msg::AbstractString, args::Dict) = debug(_lumber_mill, msg, args)
 
-info(msg::@compat(AbstractString)...; prefix = "info: ") = info(_lumber_mill, string(msg...))
+debug(msg::AbstractString...) = debug(_lumber_mill, string(msg...))
 
 
-warn(lm::LumberMill, msg::@compat(AbstractString), args::Dict = Dict()) = log(lm, "warn", msg, args)
+info(lm::LumberMill, msg::AbstractString, args::Dict = Dict()) = log(lm, "info", msg, args)
 
-warn(msg::@compat(AbstractString), args::Dict) = warn(_lumber_mill, msg, args)
+info(msg::AbstractString, args::Dict) = info(_lumber_mill, msg, args)
 
-function warn(msg::@compat(AbstractString)...; prefix="warning: ", once = false, key = nothing, bt = nothing)
+info(msg::AbstractString...; prefix = "info: ") = info(_lumber_mill, string(msg...))
+
+
+warn(lm::LumberMill, msg::AbstractString, args::Dict = Dict()) = log(lm, "warn", msg, args)
+
+warn(msg::AbstractString, args::Dict) = warn(_lumber_mill, msg, args)
+
+function warn(msg::AbstractString...; prefix="warning: ", once = false, key = nothing, bt = nothing)
     str = chomp(bytestring(msg...))
 
     if once
@@ -87,14 +87,14 @@ function warn(msg::@compat(AbstractString)...; prefix="warning: ", once = false,
         push!(Base.have_warned, key)
     end
 
-    warn(_lumber_mill, str, bt !== nothing ? @compat(Dict{Symbol,Any}(:backtrace => sprint(show_backtrace, bt))) : Dict())
+    warn(_lumber_mill, str, bt !== nothing ? Dict{Symbol,Any}(:backtrace => sprint(show_backtrace, bt)) : Dict())
 end
 
 warn(err::Exception; prefix = "error: ", kw...) =
     warn(sprint(io->showerror(io,err)), prefix = prefix; kw...)
 
 
-function error(lm::LumberMill, msg::@compat(AbstractString), args::Dict = Dict())
+function error(lm::LumberMill, msg::AbstractString, args::Dict = Dict())
     exception_msg = copy(msg)
     length(args) > 0 && (exception_msg *= " $args")
 
@@ -103,7 +103,7 @@ function error(lm::LumberMill, msg::@compat(AbstractString), args::Dict = Dict()
     throw(ErrorException(exception_msg))
 end
 
-error(msg::@compat(AbstractString), args::Dict) = error(_lumber_mill, msg, args)
+error(msg::AbstractString, args::Dict) = error(_lumber_mill, msg, args)
 
 error(msg...) = error(_lumber_mill, string(msg...))
 
@@ -127,19 +127,11 @@ function remove_saws(lm::LumberMill = _lumber_mill)
 end
 
 
-if VERSION < v"0.4.0-"
-    function add_truck(lm::LumberMill, truck::TimberTruck, name = string(UUID.v4()))
-        lm.timber_trucks[name] = truck
-    end
-
-    add_truck(truck::TimberTruck, name = string(UUID.v4())) = add_truck(_lumber_mill, truck, name)
-else
-    function add_truck(lm::LumberMill, truck::TimberTruck, name = string(Base.Random.uuid4()))
-        lm.timber_trucks[name] = truck
-    end
-
-    add_truck(truck::TimberTruck, name = string(Base.Random.uuid4())) = add_truck(_lumber_mill, truck, name)
+function add_truck(lm::LumberMill, truck::TimberTruck, name = string(Base.Random.uuid4()))
+    lm.timber_trucks[name] = truck
 end
+
+add_truck(truck::TimberTruck, name = string(Base.Random.uuid4())) = add_truck(_lumber_mill, truck, name)
 
 
 function remove_truck(lm::LumberMill, name)

--- a/src/lumbermill.jl
+++ b/src/lumbermill.jl
@@ -107,6 +107,29 @@ error(msg::AbstractString, args::Dict) = error(_lumber_mill, msg, args)
 
 error(msg...) = error(_lumber_mill, string(msg...))
 
+# -------
+
+# Allow the args dict to be passed in by kwargs instead.
+
+function log(lm::LumberMill, mode::AbstractString, msg::AbstractString; kwargs...)
+    log(lm, mode, msg, Dict{Symbol, Any}(kwargs))
+end
+
+function log(mode::AbstractString, msg::AbstractString; kwargs...)
+    log(_lumber_mill, mode, msg; kwargs...)
+end
+
+for mode in (:debug, :info, :warn, :error)
+    @eval begin
+        function $mode(lm::LumberMill, msg::AbstractString; kwargs...)
+            $mode(lm, msg, Dict{Symbol, Any}(kwargs))
+        end
+
+        $mode(msg::AbstractString; kwargs...) = $mode(_lumber_mill, msg; kwargs...)
+    end
+end
+
+# -------
 
 function add_saw(lm::LumberMill, saw_fn::Function, index = length(lm.saws)+1)
     insert!(lm.saws, index, saw_fn)

--- a/src/saws.jl
+++ b/src/saws.jl
@@ -1,22 +1,27 @@
-
 # -------
 
 msec_date_saw(args::Dict) = setindex!(args, now(), :date)
 
 function fn_call_saw(args::Dict)
-    lookup = [ccall(:jl_lookup_code_address,
-                    Any,
-                    (Ptr{Void}, Int32), b, 0) for b in backtrace()]
+    # Filter out stack frames that are from Lumberjack itself.
+    stack = StackTraces.remove_frames!(
+        StackTraces.stacktrace(), [:fn_call_saw, :log, :info, :warn, :debug]
+    )
 
-    filter!(l->!isempty(l) &&
-            !any(symb->symb == l[1],
-                 [:fn_call_saw, :log, :info, :warn, :debug]),lookup)
-    if isempty(lookup)
+    if isempty(stack)
         args
     else
-        # lookup is a tuple
-        setindex!(args, lookup[1], :lookup)
+        setindex!(args, stack[1], :lookup)
     end
+end
+
+function stacktrace_saw(args::Dict)
+    # Filter out stack frames that are from Lumberjack itself.
+    stack = StackTraces.remove_frames!(
+        StackTraces.stacktrace(), [:stacktrace_saw, :log, :info, :warn, :debug]
+    )
+
+    setindex!(args, stack, :stacktrace)
 end
 
 # -------

--- a/src/saws.jl
+++ b/src/saws.jl
@@ -15,7 +15,7 @@ function fn_call_saw(args::Dict)
         args
     else
         # lookup is a tuple
-        push!(args, :lookup, lookup[1])
+        setindex!(args, lookup[1], :lookup)
     end
 end
 

--- a/src/saws.jl
+++ b/src/saws.jl
@@ -1,9 +1,11 @@
-type Saw
+immutable Saw
     saw_fn::Function
     _mode
 
     Saw(saw_fn::Function, mode=nothing) = new(saw_fn, mode)
 end
+
+call(saw::Saw, args...; kwargs...) = saw.saw_fn(args...; kwargs...)
 
 
 # -------

--- a/src/saws.jl
+++ b/src/saws.jl
@@ -1,3 +1,11 @@
+type Saw
+    saw_fn::Function
+    _mode
+
+    Saw(saw_fn::Function, mode=nothing) = new(saw_fn, mode)
+end
+
+
 # -------
 
 msec_date_saw(args::Dict) = setindex!(args, now(), :date)

--- a/src/timbertruck.jl
+++ b/src/timbertruck.jl
@@ -47,8 +47,6 @@ type LumberjackTruck <: TimberTruck
         new(out, mode, opts)
     end
 
-    LumberjackTruck(out::IO, mode = nothing) = new(out, mode)
-
     function LumberjackTruck(filename::@compat(AbstractString), mode = nothing, opts = Dict())
         file = open(filename, "a")
         setup_opts(opts)
@@ -128,9 +126,17 @@ type JsonTruck <: TimberTruck
 end
 
 function log(truck::JsonTruck, l::Dict)
+    l = copy(l)
+
     if haskey(l, :date)
         l[:date] = string(l[:date])
     end
+ 
+    if haskey(l, :lookup)
+        func, fname, linenum = l[:lookup]
+        l[:lookup] = "$(string(func))@$(basename(string(fname))):$(linenum)"
+    end
+
     println(truck.out, json(l))
     flush(truck.out)
 end

--- a/src/timbertruck.jl
+++ b/src/timbertruck.jl
@@ -117,20 +117,18 @@ function log(truck::LumberjackTruck, l::Dict)
     if isa(truck.out, Syslog)
         # Syslog needs to be explicitly told what the error level is.
         println(truck.out, mode, record)
-    else
-        if (truck.opts[:is_colorized])
-            # check if color has been defined for key
-            if (haskey(truck.opts[:colors], mode))
-                print_with_color(truck.opts[:colors][mode], truck.out, string(record,"\n"))
-            # if not, don't apply colors
-            else
-                println(truck.out, record)
-            end
+    elseif (truck.opts[:is_colorized])
+        # check if color has been defined for key
+        if (haskey(truck.opts[:colors], mode))
+            print_with_color(truck.opts[:colors][mode], truck.out, string(record,"\n"))
+        # if not, don't apply colors
         else
             println(truck.out, record)
         end
-        flush(truck.out)
+    else
+        println(truck.out, record)
     end
+    flush(truck.out)
 end
 
 # -------

--- a/src/timbertruck.jl
+++ b/src/timbertruck.jl
@@ -6,7 +6,7 @@ log(t::TimberTruck, a::Dict) = error("please implement `log(truck::$(typeof(t)),
 
 
 function configure(t::TimberTruck; mode = nothing)
-    !in(:_mode, @compat fieldnames(t)) && return
+    !in(:_mode, fieldnames(t)) && return
     t._mode = mode
 end
 
@@ -22,7 +22,7 @@ type CommonLogTruck <: TimberTruck
 
     CommonLogTruck(out::IO, mode = nothing) = new(out, mode)
 
-    function CommonLogTruck(filename::@compat(AbstractString), mode = nothing)
+    function CommonLogTruck(filename::AbstractString, mode = nothing)
         file = open(filename, "a")
         truck = new(file, mode)
         finalizer(truck, (t)->close(t.out))
@@ -47,7 +47,7 @@ type LumberjackTruck <: TimberTruck
         new(out, mode, opts)
     end
 
-    function LumberjackTruck(filename::@compat(AbstractString), mode = nothing, opts = Dict())
+    function LumberjackTruck(filename::AbstractString, mode = nothing, opts = Dict())
         file = open(filename, "a")
         setup_opts(opts)
         truck = new(file, mode, opts)
@@ -60,7 +60,7 @@ type LumberjackTruck <: TimberTruck
             opts[:is_colorized] = true
         elseif (!haskey(opts, :colors) && haskey(opts, :is_colorized) && opts[:is_colorized])
             # set default colors
-            opts[:colors] = @compat Dict{ASCIIString,Symbol}("debug" => :cyan, "info" => :blue, "warn" => :yellow, "error" => :red)
+            opts[:colors] = Dict{ASCIIString,Symbol}("debug" => :cyan, "info" => :blue, "warn" => :yellow, "error" => :red)
         else
             opts[:is_colorized] = false
         end

--- a/src/timbertruck.jl
+++ b/src/timbertruck.jl
@@ -137,7 +137,10 @@ end
 
 type JsonTruck <: TimberTruck
     out::IO
+    _mode
 end
+
+JsonTruck(out::IO) = JsonTruck(out, nothing)
 
 function log(truck::JsonTruck, l::Dict)
     l = copy(l)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+Mocking

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 
-using Lumberjack, Compat
+using Lumberjack
 
 function reset_lumberjack()
     Lumberjack.remove_trucks()
@@ -14,7 +14,7 @@ files = readdir()
 # Run each file in the test directory that looks like "test-XXXX.jl"
 # Test files should assume the global lumber mill has been reset
 for file in files
-    !(@compat startswith(file, "test-")) && continue
+    !(startswith(file, "test-") && endswith(file, ".jl")) && continue
 
     reset_lumberjack()
     include(abspath(file))

--- a/test/test-fileroller.jl
+++ b/test/test-fileroller.jl
@@ -1,6 +1,7 @@
 using Base.Test
 
-const ROLLER_PREFIX = "fileroller"
+const ROLLER_PREFIX = tempname()
+println("Path to ROLLER_PREFIX: $ROLLER_PREFIX")
 
 configure(; modes = ["debug", "info", "warn", "error", "crazy"])
 add_truck(Lumberjack.JsonTruck(Lumberjack.FileRoller(ROLLER_PREFIX)))

--- a/test/test-jsontruck.jl
+++ b/test/test-jsontruck.jl
@@ -1,6 +1,7 @@
 using Base.Test, JSON
 
-const JSON_FILE = "file.json"
+const JSON_FILE = tempname()
+println("Path to JSON_FILE: $JSON_FILE")
 
 Lumberjack.add_truck(JsonTruck(open(JSON_FILE, "w")))
 
@@ -23,11 +24,11 @@ log("crazy", "some-msg")
 remove_saws()
 
 # test with extra params
-log("debug", "some-msg", @compat Dict{Any,Any}( :thing1 => "thing1" ))
-log("info", "some-msg", @compat Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69 ))
-log("warn", "some-msg", @compat Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3] ))
-log("error", "some-msg",  @compat Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" )))
-log("crazy", "some-msg",  @compat Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" ), :thing5 => :some_symbol ))
+log("debug", "some-msg", Dict{Any,Any}( :thing1 => "thing1" ))
+log("info", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69 ))
+log("warn", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3] ))
+log("error", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" )))
+log("crazy", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" ), :thing5 => :some_symbol ))
 
 js = JSON.parse("[$(join(readlines(open(JSON_FILE)), ','))]")
 

--- a/test/test-jsontruck.jl
+++ b/test/test-jsontruck.jl
@@ -12,7 +12,7 @@ log("warn", "some-msg")
 log("error", "some-msg")
 log("crazy", "some-msg")
 
-# test with dates
+# test with msec_date_saw
 add_saw(Lumberjack.msec_date_saw)
 
 log("debug", "some-msg")
@@ -20,6 +20,25 @@ log("info", "some-msg")
 log("warn", "some-msg")
 log("error", "some-msg")
 log("crazy", "some-msg")
+
+remove_saws()
+
+# test with fn_call_saw
+add_saw(Lumberjack.fn_call_saw)
+
+@noinline caller(mode, msg) = log(mode, msg)
+caller("debug", "some-msg")
+caller("info", "some-msg")
+
+remove_saws()
+
+# test with stacktrace_saw
+add_saw(Lumberjack.stacktrace_saw)
+
+@noinline child_caller(mode, msg) = log(mode, msg)
+@noinline parent_caller(mode, msg) = child_caller(mode, msg)
+parent_caller("warn", "some-msg")
+parent_caller("error", "some-msg")
 
 remove_saws()
 
@@ -40,23 +59,34 @@ for i = 6:10
     @test haskey(js[i], "date")
 end
 
-for i = 11:15
+for i = 11:12
+    @test js[i]["lookup"]["name"] == "caller"
+end
+
+for i = 13:14
+    @test js[i]["stacktrace"][1]["name"] == "child_caller"
+    @test js[i]["stacktrace"][1]["file"] == basename(string(@__FILE__))
+    @test js[i]["stacktrace"][2]["name"] == "parent_caller"
+    @test js[i]["stacktrace"][2]["file"] == basename(string(@__FILE__))
+end
+
+for i = 15:19
     @test js[i]["thing1"] == "thing1"
 end
 
-for i = 12:15
+for i = 16:19
     @test js[i]["thing2"] == 69
 end
 
-for i = 13:15
+for i = 17:19
     @test js[i]["thing3"] == [1, 2, 3]
 end
 
-for i = 14:15
+for i = 18:19
     @test js[i]["thing4"]["a"] == "apple"
 end
 
-@test js[15]["thing5"] == "some_symbol"
+@test js[19]["thing5"] == "some_symbol"
 
 # clean up
 @test success(`rm $JSON_FILE`)

--- a/test/test-lumberjack-opts.jl
+++ b/test/test-lumberjack-opts.jl
@@ -1,9 +1,10 @@
 using Base.Test
 
-const LOG_FILE_OPTS = "lumberjacklog-out-opts.log"
+const LOG_FILE_OPTS = tempname()
+println("Path to LOG_FILE_OPTS: $LOG_FILE_OPTS")
 
 configure(; modes = ["debug", "info", "warn", "error", "crazy"])
-add_truck(Lumberjack.LumberjackTruck(LOG_FILE_OPTS, nothing, @compat Dict{Any,Any}(:is_colorized => true, :uppercase => true)), "colorlumberjacklogfile")
+add_truck(Lumberjack.LumberjackTruck(LOG_FILE_OPTS, nothing, Dict{Any,Any}(:is_colorized => true, :uppercase => true)), "colorlumberjacklogfile")
 
 log("debug", "some-msg")
 log("info", "some-msg")
@@ -14,7 +15,7 @@ log("crazy", "some-msg")
 remove_truck("optslumberjacklogfile")
 
 # custom colors
-add_truck(Lumberjack.LumberjackTruck(LOG_FILE_OPTS, nothing, @compat Dict{Any,Any}(:colors => Dict{Any,Any}("debug" => :black, "info" => :red, "crazy" => :green), :uppercase => true)), "optslumberjacklogfile")
+add_truck(Lumberjack.LumberjackTruck(LOG_FILE_OPTS, nothing, Dict{Any,Any}(:colors => Dict{Any,Any}("debug" => :black, "info" => :red, "crazy" => :green), :uppercase => true)), "optslumberjacklogfile")
 
 log("debug", "some-msg")
 log("info", "some-msg")
@@ -26,29 +27,16 @@ log_lines = readlines(open(LOG_FILE_OPTS, "r"))
 
 # default colors: {"debug" => :cyan, "info" => :blue, "warn" => :yellow, "error" => :red}
 # test with default colors
-if VERSION >= v"0.4-"
-    @test log_lines[1] == "$(Base.text_colors[:cyan])DEBUG: some-msg\n"
-    @test log_lines[2] == "$(Base.text_colors[:normal]Base.text_colors[:blue])INFO: some-msg\n"
-    @test log_lines[3] == "$(Base.text_colors[:normal]Base.text_colors[:yellow])WARN: some-msg\n"
-    @test log_lines[4] == "$(Base.text_colors[:normal]Base.text_colors[:red])ERROR: some-msg\n"
-    @test log_lines[5] == "$(Base.text_colors[:normal])CRAZY: some-msg\n"
+@test log_lines[1] == "$(Base.text_colors[:cyan])DEBUG: some-msg\n"
+@test log_lines[2] == "$(Base.text_colors[:normal]Base.text_colors[:blue])INFO: some-msg\n"
+@test log_lines[3] == "$(Base.text_colors[:normal]Base.text_colors[:yellow])WARN: some-msg\n"
+@test log_lines[4] == "$(Base.text_colors[:normal]Base.text_colors[:red])ERROR: some-msg\n"
+@test log_lines[5] == "$(Base.text_colors[:normal])CRAZY: some-msg\n"
 
-    # test with custom colors
-    @test log_lines[6] == "$(Base.text_colors[:black])DEBUG: some-msg\n"
-    @test log_lines[7] == "$(Base.text_colors[:normal]Base.text_colors[:red])INFO: some-msg\n"
-    @test log_lines[8] == "$(Base.text_colors[:normal]Base.text_colors[:green])CRAZY: some-msg\n"
-else
-    @test contains(log_lines[1], "DEBUG: some-msg\n")
-    @test contains(log_lines[2], "INFO: some-msg\n")
-    @test contains(log_lines[3], "WARN: some-msg\n")
-    @test contains(log_lines[4], "ERROR: some-msg\n")
-    @test contains(log_lines[5], "CRAZY: some-msg\n")
-
-    # test with custom colors
-    @test contains(log_lines[6], "DEBUG: some-msg\n")
-    @test contains(log_lines[7], "INFO: some-msg\n")
-    @test contains(log_lines[8], "CRAZY: some-msg\n")
-end
+# test with custom colors
+@test log_lines[6] == "$(Base.text_colors[:black])DEBUG: some-msg\n"
+@test log_lines[7] == "$(Base.text_colors[:normal]Base.text_colors[:red])INFO: some-msg\n"
+@test log_lines[8] == "$(Base.text_colors[:normal]Base.text_colors[:green])CRAZY: some-msg\n"
 
 # clean up
 @test success(`rm $LOG_FILE_OPTS`)

--- a/test/test-lumberjacktruck.jl
+++ b/test/test-lumberjacktruck.jl
@@ -1,7 +1,8 @@
 
 using Base.Test
 
-const LOG_FILE = "lumberjacklog-out.log"
+const LOG_FILE = tempname()
+println("Path to LOG_FILE: $LOG_FILE")
 
 configure(; modes = ["debug", "info", "warn", "error", "crazy"])
 add_truck(Lumberjack.LumberjackTruck(LOG_FILE), "lumberjacklogfile")
@@ -28,11 +29,11 @@ remove_saws()
 
 
 # test with extra params
-log("debug", "some-msg", @compat Dict{Any,Any}( :thing1 => "thing1" ))
-log("info", "some-msg", @compat Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69 ))
-log("warn", "some-msg", @compat Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3] ))
-log("error", "some-msg",  @compat Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" )))
-log("crazy", "some-msg",  @compat Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" ), :thing5 => :some_symbol ))
+log("debug", "some-msg", Dict{Any,Any}( :thing1 => "thing1" ))
+log("info", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69 ))
+log("warn", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3] ))
+log("error", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" )))
+log("crazy", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" ), :thing5 => :some_symbol ))
 
 # -------
 

--- a/test/test-lumberjacktruck.jl
+++ b/test/test-lumberjacktruck.jl
@@ -8,7 +8,7 @@ configure(; modes = ["debug", "info", "warn", "error", "crazy"])
 add_truck(Lumberjack.LumberjackTruck(LOG_FILE), "lumberjacklogfile")
 
 
-# test without dates
+# test without extra saws
 log("debug", "some-msg")
 log("info", "some-msg")
 log("warn", "some-msg")
@@ -16,7 +16,7 @@ log("error", "some-msg")
 log("crazy", "some-msg")
 
 
-# test with dates
+# test with msec_date_saw
 add_saw(Lumberjack.msec_date_saw)
 
 log("debug", "some-msg")
@@ -24,6 +24,27 @@ log("info", "some-msg")
 log("warn", "some-msg")
 log("error", "some-msg")
 log("crazy", "some-msg")
+
+remove_saws()
+
+
+# test with fn_call_saw
+add_saw(Lumberjack.fn_call_saw)
+
+@noinline caller(mode, msg) = log(mode, msg)
+caller("debug", "some-msg")
+caller("info", "some-msg")
+
+remove_saws()
+
+
+# test with stacktrace_saw
+add_saw(Lumberjack.stacktrace_saw)
+
+@noinline child_caller(mode, msg) = log(mode, msg)
+@noinline parent_caller(mode, msg) = child_caller(mode, msg)
+parent_caller("warn", "some-msg")
+parent_caller("error", "some-msg")
 
 remove_saws()
 
@@ -48,77 +69,101 @@ log("crazy", "some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3], thing4=Di
 
 remove_truck("lumberjacklogfile")
 log_lines = readlines(open(LOG_FILE, "r"))
+line = 0
 
 
-# test without dates
-@test log_lines[1] == "debug: some-msg\n"
-@test log_lines[2] == "info: some-msg\n"
-@test log_lines[3] == "warn: some-msg\n"
-@test log_lines[4] == "error: some-msg\n"
-@test log_lines[5] == "crazy: some-msg\n"
+# test without extra saws
+line += 1; @test log_lines[line] == "debug: some-msg\n"
+line += 1; @test log_lines[line] == "info: some-msg\n"
+line += 1; @test log_lines[line] == "warn: some-msg\n"
+line += 1; @test log_lines[line] == "error: some-msg\n"
+line += 1; @test log_lines[line] == "crazy: some-msg\n"
 
 
-# test with dates
+# test with msec_date_saw
 date_regex = r"[\/|\-|\.|,|\s]"
-@test ismatch(date_regex, log_lines[6])
-@test ismatch(date_regex, log_lines[7])
-@test ismatch(date_regex, log_lines[8])
-@test ismatch(date_regex, log_lines[9])
-@test ismatch(date_regex, log_lines[10])
+line += 1; @test ismatch(date_regex, log_lines[line])
+line += 1; @test ismatch(date_regex, log_lines[line])
+line += 1; @test ismatch(date_regex, log_lines[line])
+line += 1; @test ismatch(date_regex, log_lines[line])
+line += 1; @test ismatch(date_regex, log_lines[line])
+
+
+# test with fn_call_saw
+fn_regex = "caller@\\Q$(basename(@__FILE__))\\E:\\d+"
+line += 1; @test ismatch(Regex(fn_regex * ".+debug: some-msg"), log_lines[line])
+line += 1; @test ismatch(Regex(fn_regex * ".+info: some-msg"), log_lines[line])
+
+
+# test with stacktrace_saw
+stackframe = "@\\Q$(basename(@__FILE__))\\E:\\d+"
+stacktrace_regex = string("child_caller", stackframe, ", parent_caller", stackframe)
+line += 1; @test ismatch(Regex("warn: some-msg.+" * stacktrace_regex), log_lines[line])
+line += 1; @test ismatch(Regex("error: some-msg.+" * stacktrace_regex), log_lines[line])
 
 
 # test with extra params
-@test contains(log_lines[11], "debug: some-msg")
-@test contains(log_lines[11], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "debug: some-msg")
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
-@test contains(log_lines[12], "info: some-msg")
-@test contains(log_lines[12], "thing2:69")
-@test contains(log_lines[12], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "info: some-msg")
+@test contains(log_lines[line], "thing2:69")
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
-@test contains(log_lines[13], "warn: some-msg")
-@test contains(log_lines[13], "thing2:69")
-@test contains(log_lines[13], "thing3:[1,2,3]")
-@test contains(log_lines[13], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "warn: some-msg")
+@test contains(log_lines[line], "thing2:69")
+@test contains(log_lines[line], "thing3:[1,2,3]")
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
-@test contains(log_lines[14], "error: some-msg")
-@test contains(log_lines[14], "thing2:69")
-@test contains(log_lines[14], "thing3:[1,2,3]")
-@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[14])
-@test contains(log_lines[14], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "error: some-msg")
+@test contains(log_lines[line], "thing2:69")
+@test contains(log_lines[line], "thing3:[1,2,3]")
+@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[line])
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
-@test contains(log_lines[15], "crazy: some-msg")
-@test contains(log_lines[15], "thing2:69")
-@test contains(log_lines[15], "thing5::some_symbol")
-@test contains(log_lines[15], "thing3:[1,2,3]")
-@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[15])
-@test contains(log_lines[15], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "crazy: some-msg")
+@test contains(log_lines[line], "thing2:69")
+@test contains(log_lines[line], "thing5::some_symbol")
+@test contains(log_lines[line], "thing3:[1,2,3]")
+@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[line])
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
 
 # test with kwarg params
-@test contains(log_lines[16], "debug: some-msg")
-@test contains(log_lines[16], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "debug: some-msg")
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
-@test contains(log_lines[17], "info: some-msg")
-@test contains(log_lines[17], "thing2:69")
-@test contains(log_lines[17], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "info: some-msg")
+@test contains(log_lines[line], "thing2:69")
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
-@test contains(log_lines[18], "warn: some-msg")
-@test contains(log_lines[18], "thing2:69")
-@test contains(log_lines[18], "thing3:[1,2,3]")
-@test contains(log_lines[18], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "warn: some-msg")
+@test contains(log_lines[line], "thing2:69")
+@test contains(log_lines[line], "thing3:[1,2,3]")
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
-@test contains(log_lines[19], "error: some-msg")
-@test contains(log_lines[19], "thing2:69")
-@test contains(log_lines[19], "thing3:[1,2,3]")
-@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[19])
-@test contains(log_lines[19], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "error: some-msg")
+@test contains(log_lines[line], "thing2:69")
+@test contains(log_lines[line], "thing3:[1,2,3]")
+@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[line])
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
-@test contains(log_lines[20], "crazy: some-msg")
-@test contains(log_lines[20], "thing2:69")
-@test contains(log_lines[20], "thing5::some_symbol")
-@test contains(log_lines[20], "thing3:[1,2,3]")
-@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[20])
-@test contains(log_lines[20], "thing1:\"thing1\"")
+line += 1
+@test contains(log_lines[line], "crazy: some-msg")
+@test contains(log_lines[line], "thing2:69")
+@test contains(log_lines[line], "thing5::some_symbol")
+@test contains(log_lines[line], "thing3:[1,2,3]")
+@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[line])
+@test contains(log_lines[line], "thing1:\"thing1\"")
 
 # clean up
 @test success(`rm $LOG_FILE`)

--- a/test/test-lumberjacktruck.jl
+++ b/test/test-lumberjacktruck.jl
@@ -35,6 +35,15 @@ log("warn", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thin
 log("error", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" )))
 log("crazy", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" ), :thing5 => :some_symbol ))
 
+
+# test with kwarg params
+debug("some-msg"; thing1="thing1")
+Lumberjack.info("some-msg"; thing1="thing1", thing2=69)
+Lumberjack.warn("some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3])
+@test_throws ErrorException Lumberjack.error("some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3], thing4=Dict{Any,Any}("a" => "apple"))
+log("crazy", "some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3], thing4=Dict{Any,Any}("a" => "apple"), thing5=:some_symbol)
+
+
 # -------
 
 remove_truck("lumberjacklogfile")
@@ -66,7 +75,6 @@ date_regex = r"[\/|\-|\.|,|\s]"
 @test contains(log_lines[12], "thing2:69")
 @test contains(log_lines[12], "thing1:\"thing1\"")
 
-
 @test contains(log_lines[13], "warn: some-msg")
 @test contains(log_lines[13], "thing2:69")
 @test contains(log_lines[13], "thing3:[1,2,3]")
@@ -84,6 +92,33 @@ date_regex = r"[\/|\-|\.|,|\s]"
 @test contains(log_lines[15], "thing3:[1,2,3]")
 @test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[15])
 @test contains(log_lines[15], "thing1:\"thing1\"")
+
+
+# test with kwarg params
+@test contains(log_lines[16], "debug: some-msg")
+@test contains(log_lines[16], "thing1:\"thing1\"")
+
+@test contains(log_lines[17], "info: some-msg")
+@test contains(log_lines[17], "thing2:69")
+@test contains(log_lines[17], "thing1:\"thing1\"")
+
+@test contains(log_lines[18], "warn: some-msg")
+@test contains(log_lines[18], "thing2:69")
+@test contains(log_lines[18], "thing3:[1,2,3]")
+@test contains(log_lines[18], "thing1:\"thing1\"")
+
+@test contains(log_lines[19], "error: some-msg")
+@test contains(log_lines[19], "thing2:69")
+@test contains(log_lines[19], "thing3:[1,2,3]")
+@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[19])
+@test contains(log_lines[19], "thing1:\"thing1\"")
+
+@test contains(log_lines[20], "crazy: some-msg")
+@test contains(log_lines[20], "thing2:69")
+@test contains(log_lines[20], "thing5::some_symbol")
+@test contains(log_lines[20], "thing3:[1,2,3]")
+@test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[20])
+@test contains(log_lines[20], "thing1:\"thing1\"")
 
 # clean up
 @test success(`rm $LOG_FILE`)

--- a/test/test-lumberjacktruck.jl
+++ b/test/test-lumberjacktruck.jl
@@ -105,65 +105,65 @@ line += 1; @test ismatch(Regex("error: some-msg.+" * stacktrace_regex), log_line
 # test with extra params
 line += 1
 @test contains(log_lines[line], "debug: some-msg")
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 line += 1
 @test contains(log_lines[line], "info: some-msg")
-@test contains(log_lines[line], "thing2:69")
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing2: 69")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 line += 1
 @test contains(log_lines[line], "warn: some-msg")
-@test contains(log_lines[line], "thing2:69")
-@test contains(log_lines[line], "thing3:[1,2,3]")
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing2: 69")
+@test contains(log_lines[line], "thing3: [1,2,3]")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 line += 1
 @test contains(log_lines[line], "error: some-msg")
-@test contains(log_lines[line], "thing2:69")
-@test contains(log_lines[line], "thing3:[1,2,3]")
+@test contains(log_lines[line], "thing2: 69")
+@test contains(log_lines[line], "thing3: [1,2,3]")
 @test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[line])
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 line += 1
 @test contains(log_lines[line], "crazy: some-msg")
-@test contains(log_lines[line], "thing2:69")
-@test contains(log_lines[line], "thing5::some_symbol")
-@test contains(log_lines[line], "thing3:[1,2,3]")
+@test contains(log_lines[line], "thing2: 69")
+@test contains(log_lines[line], "thing5: :some_symbol")
+@test contains(log_lines[line], "thing3: [1,2,3]")
 @test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[line])
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 
 # test with kwarg params
 line += 1
 @test contains(log_lines[line], "debug: some-msg")
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 line += 1
 @test contains(log_lines[line], "info: some-msg")
-@test contains(log_lines[line], "thing2:69")
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing2: 69")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 line += 1
 @test contains(log_lines[line], "warn: some-msg")
-@test contains(log_lines[line], "thing2:69")
-@test contains(log_lines[line], "thing3:[1,2,3]")
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing2: 69")
+@test contains(log_lines[line], "thing3: [1,2,3]")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 line += 1
 @test contains(log_lines[line], "error: some-msg")
-@test contains(log_lines[line], "thing2:69")
-@test contains(log_lines[line], "thing3:[1,2,3]")
+@test contains(log_lines[line], "thing2: 69")
+@test contains(log_lines[line], "thing3: [1,2,3]")
 @test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[line])
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 line += 1
 @test contains(log_lines[line], "crazy: some-msg")
-@test contains(log_lines[line], "thing2:69")
-@test contains(log_lines[line], "thing5::some_symbol")
-@test contains(log_lines[line], "thing3:[1,2,3]")
+@test contains(log_lines[line], "thing2: 69")
+@test contains(log_lines[line], "thing5: :some_symbol")
+@test contains(log_lines[line], "thing3: [1,2,3]")
 @test ismatch(r"thing4:.*\"a\"=>\"apple\"", log_lines[line])
-@test contains(log_lines[line], "thing1:\"thing1\"")
+@test contains(log_lines[line], "thing1: \"thing1\"")
 
 # clean up
 @test success(`rm $LOG_FILE`)

--- a/test/test-modes.jl
+++ b/test/test-modes.jl
@@ -1,0 +1,28 @@
+using Base.Test
+
+const MODE_LOG_FILE = tempname()
+println("Path to MODE_LOG_FILE: $MODE_LOG_FILE")
+
+configure(; modes = ["debug", "info", "warn", "error", "crazy"])
+add_truck(Lumberjack.LumberjackTruck(MODE_LOG_FILE, "info"), "infotruck")
+add_saw(Lumberjack.Saw(Lumberjack.fn_call_saw, "error"))
+
+# Test limiting trucks and saws to certain log levels.
+@noinline caller(mode, msg) = log(mode, msg)
+caller("debug", "Message")  # Not logged.
+caller("info", "Message")   # Logged.
+caller("warn", "Message")   # Logged.
+caller("error", "Message")  # Logged with function call.
+caller("crazy", "Message")  # Logged with function call.
+
+remove_truck("infotruck")
+log_lines = readlines(open(MODE_LOG_FILE, "r"))
+
+fn_regex = "caller@\\Q$(basename(@__FILE__))\\E:\\d+"
+@test log_lines[1] == "info: Message\n"
+@test log_lines[2] == "warn: Message\n"
+@test ismatch(Regex(fn_regex * ".+error: Message"), log_lines[3])
+@test ismatch(Regex(fn_regex * ".+crazy: Message"), log_lines[4])
+
+# Clean up.
+@test success(`rm $MODE_LOG_FILE`)

--- a/test/test-syslog.jl
+++ b/test/test-syslog.jl
@@ -1,0 +1,20 @@
+using Base.Test, Lumberjack
+import Mocking: mend
+
+modes = ["debug", "info", "notice", "warning", "err", "crit", "alert", "emerg"]
+configure(; modes=[modes..., "invalid-syslog-level"])
+Lumberjack.add_truck(LumberjackTruck(Syslog(:local0, "julia")))
+
+# Syslog uses an external call to logger to do its legwork. Because the syslog itself can be
+# essentially anywhere (we might not have permission to read it, and it might not even be on
+# the same machine), we'll just make sure that the external call to logger itself is right.
+history = []
+mend(run, command::Cmd -> push!(history, string(command))) do
+    for mode in modes
+        log(mode, "Message")
+        @test history[end] == string(`logger -t julia -p local0.$(mode) "$(mode): Message"`)
+    end
+
+    # Syslog only accepts certain predefined loglevels.
+    @test_throws ErrorException log("invalid-syslog-level", "Message")
+end


### PR DESCRIPTION
On systems with `logger`, Lumberjack can output to syslog (closes #23).
New `stacktrace_saw` can add full stack traces to logs (especially useful for JSON parsing).
Saws can now be limited to certain log modes only (just like timber trucks).
Extra logging params (the `args` Dict) can now be specified with kwargs instead.
Bugfix for `JsonTruck` not supporting log level/mode limits.
Bugfix for `JsonTruck` not displaying output from `fn_call_saw` correctly.
Bugfix for log files created by test cases not being removed on test failure (which meant one test failure resulted in perpetual test failure until the test files were manually removed).
Added missing tests for `fn_call_saw`.
Added missing tests for mode/log level restrictions.
Several helpful examples added to the README.
Unfortunately `StackTraces.jl` only supports 0.4+ (due to differences in the way backtraces are resolved pre-0.4), so support for 0.3 has been removed (which cleans up the code a bit).