### PR TITLE
fix FileRoller constructor when using a directory

### DIFF
--- a/src/FileRoller.jl
+++ b/src/FileRoller.jl
@@ -29,9 +29,9 @@ function getfile(folder::AbstractString, prefix::AbstractString)
     p, open(p, "a")
 end
 
-FileRoller(prefix) = FileRoller(prefix, pwd(), (getfile(pwd(), prefix))..., 0)
+FileRoller(prefix) = FileRoller(prefix, pwd())
 
-FileRoller(prefix, dir) = FileRoller((getfile(dir, prefix))...)
+FileRoller(prefix, dir) = FileRoller(prefix, dir, (getfile(dir, prefix))..., 0)
 
 function println(f::FileRoller, s::AbstractString)
     if f.byteswritten > FILE_SIZE


### PR DESCRIPTION
`FileRoller(prefix, dir)` was recursively calling itself with incorrect arguments.  Fixed.