### PR TITLE
No longer requres external StackTraces package

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 
 JSON
 StackTraces 0.1
+Mocking

--- a/src/Lumberjack.jl
+++ b/src/Lumberjack.jl
@@ -2,7 +2,15 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
 module Lumberjack
 
-import Base.show, Base.error, Base.warn, Base.info, Base.log, StackTraces
+import Base.show, Base.error, Base.warn, Base.info, Base.log
+import Mocking: @mendable
+
+if !isdefined(Base, :StackTraces)
+    import StackTraces
+end
+
+# To avoid warnings, intentionally do not import:
+# Base.error, Base.warn, Base.info
 
 export log,
        debug, info, warn, error,

--- a/src/Syslog.jl
+++ b/src/Syslog.jl
@@ -39,7 +39,9 @@ function println(log::Syslog, level::Symbol, msg::AbstractString)
     end
 
     tag = log.tag * (log.pid > -1 ? "[$(log.pid)]" : "")
-    run(`logger -t $(tag) -p $(log.facility).$level $msg`)
+
+    # @mendable is required to allow the test cases to modify the run command for testing.
+    @mendable run(`logger -t $(tag) -p $(log.facility).$level $msg`)
 end
 
 function println(log::Syslog, level::AbstractString, msg::AbstractString)

--- a/src/lumbermill.jl
+++ b/src/lumbermill.jl
@@ -32,7 +32,7 @@ end
 configure(; args...) = configure(_lumber_mill; args...)
 
 
-function log(lm::LumberMill, mode::AbstractString, msg::AbstractString, args::Dict = Dict())
+function log(lm::LumberMill, mode::AbstractString, msg::AbstractString, args::Dict)
     args[:mode] = mode
     args[:msg] = msg
 
@@ -58,26 +58,26 @@ function log(lm::LumberMill, mode::AbstractString, msg::AbstractString, args::Di
     end
 end
 
-log(mode::AbstractString, msg::AbstractString, args::Dict = Dict()) = log(_lumber_mill, mode, msg, args)
+log(mode::AbstractString, msg::AbstractString, args::Dict) = log(_lumber_mill, mode, msg, args)
 
-log(mode::AbstractString, args::Dict = Dict()) = log(_lumber_mill, mode, "", args)
+log(mode::AbstractString, args::Dict) = log(_lumber_mill, mode, "", args)
 
 
-debug(lm::LumberMill, msg::AbstractString, args::Dict = Dict()) = log(lm, "debug", msg, args)
+debug(lm::LumberMill, msg::AbstractString, args::Dict) = log(lm, "debug", msg, args)
 
 debug(msg::AbstractString, args::Dict) = debug(_lumber_mill, msg, args)
 
 debug(msg::AbstractString...) = debug(_lumber_mill, string(msg...))
 
 
-info(lm::LumberMill, msg::AbstractString, args::Dict = Dict()) = log(lm, "info", msg, args)
+info(lm::LumberMill, msg::AbstractString, args::Dict) = log(lm, "info", msg, args)
 
 info(msg::AbstractString, args::Dict) = info(_lumber_mill, msg, args)
 
 info(msg::AbstractString...; prefix = "info: ") = info(_lumber_mill, string(msg...))
 
 
-warn(lm::LumberMill, msg::AbstractString, args::Dict = Dict()) = log(lm, "warn", msg, args)
+warn(lm::LumberMill, msg::AbstractString, args::Dict) = log(lm, "warn", msg, args)
 
 warn(msg::AbstractString, args::Dict) = warn(_lumber_mill, msg, args)
 
@@ -100,7 +100,7 @@ warn(err::Exception; prefix = "error: ", kw...) =
     warn(sprint(io->showerror(io,err)), prefix = prefix; kw...)
 
 
-function error(lm::LumberMill, msg::AbstractString, args::Dict = Dict())
+function error(lm::LumberMill, msg::AbstractString, args::Dict)
     exception_msg = copy(msg)
     length(args) > 0 && (exception_msg *= " $args")
 
@@ -110,8 +110,6 @@ function error(lm::LumberMill, msg::AbstractString, args::Dict = Dict())
 end
 
 error(msg::AbstractString, args::Dict) = error(_lumber_mill, msg, args)
-
-error(msg::AbstractString) = error(_lumber_mill, msg)
 
 error(msg...) = error(_lumber_mill, string(msg...))
 
@@ -125,6 +123,10 @@ end
 
 function log(mode::AbstractString, msg::AbstractString; kwargs...)
     log(_lumber_mill, mode, msg; kwargs...)
+end
+
+function log(mode::AbstractString; kwargs...)
+    log(_lumber_mill, mode, ""; kwargs...)
 end
 
 for mode in (:debug, :info, :warn, :error)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-Mocking

--- a/test/test-jsontruck.jl
+++ b/test/test-jsontruck.jl
@@ -26,28 +26,30 @@ remove_saws()
 # test with fn_call_saw
 add_saw(Lumberjack.fn_call_saw)
 
-@noinline caller(mode, msg) = log(mode, msg)
-caller("debug", "some-msg")
-caller("info", "some-msg")
+let
+    @noinline caller(mode, msg) = log(mode, msg)
+    caller("debug", "some-msg")
+    caller("info", "some-msg")
 
-remove_saws()
+    remove_saws()
 
-# test with stacktrace_saw
-add_saw(Lumberjack.stacktrace_saw)
+    # test with stacktrace_saw
+    add_saw(Lumberjack.stacktrace_saw)
 
-@noinline child_caller(mode, msg) = log(mode, msg)
-@noinline parent_caller(mode, msg) = child_caller(mode, msg)
-parent_caller("warn", "some-msg")
-parent_caller("error", "some-msg")
+    @noinline child_caller(mode, msg) = log(mode, msg)
+    @noinline parent_caller(mode, msg) = child_caller(mode, msg)
+    parent_caller("warn", "some-msg")
+    parent_caller("error", "some-msg")
 
-remove_saws()
+    remove_saws()
 
-# test with extra params
-log("debug", "some-msg", Dict{Any,Any}( :thing1 => "thing1" ))
-log("info", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69 ))
-log("warn", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3] ))
-log("error", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" )))
-log("crazy", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" ), :thing5 => :some_symbol ))
+    # test with extra params
+    log("debug", "some-msg", Dict{Any,Any}( :thing1 => "thing1" ))
+    log("info", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69 ))
+    log("warn", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3] ))
+    log("error", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" )))
+    log("crazy", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" ), :thing5 => :some_symbol ))
+end
 
 js = JSON.parse("[$(join(readlines(open(JSON_FILE)), ','))]")
 

--- a/test/test-lumberjacktruck.jl
+++ b/test/test-lumberjacktruck.jl
@@ -31,38 +31,40 @@ remove_saws()
 # test with fn_call_saw
 add_saw(Lumberjack.fn_call_saw)
 
-@noinline caller(mode, msg) = log(mode, msg)
-caller("debug", "some-msg")
-caller("info", "some-msg")
+let
+    @noinline caller(mode, msg) = log(mode, msg)
+    caller("debug", "some-msg")
+    caller("info", "some-msg")
 
-remove_saws()
-
-
-# test with stacktrace_saw
-add_saw(Lumberjack.stacktrace_saw)
-
-@noinline child_caller(mode, msg) = log(mode, msg)
-@noinline parent_caller(mode, msg) = child_caller(mode, msg)
-parent_caller("warn", "some-msg")
-parent_caller("error", "some-msg")
-
-remove_saws()
+    remove_saws()
 
 
-# test with extra params
-log("debug", "some-msg", Dict{Any,Any}( :thing1 => "thing1" ))
-log("info", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69 ))
-log("warn", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3] ))
-log("error", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" )))
-log("crazy", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" ), :thing5 => :some_symbol ))
+    # test with stacktrace_saw
+    add_saw(Lumberjack.stacktrace_saw)
+
+    @noinline child_caller(mode, msg) = log(mode, msg)
+    @noinline parent_caller(mode, msg) = child_caller(mode, msg)
+    parent_caller("warn", "some-msg")
+    parent_caller("error", "some-msg")
+
+    remove_saws()
 
 
-# test with kwarg params
-debug("some-msg"; thing1="thing1")
-Lumberjack.info("some-msg"; thing1="thing1", thing2=69)
-Lumberjack.warn("some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3])
-@test_throws ErrorException Lumberjack.error("some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3], thing4=Dict{Any,Any}("a" => "apple"))
-log("crazy", "some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3], thing4=Dict{Any,Any}("a" => "apple"), thing5=:some_symbol)
+    # test with extra params
+    log("debug", "some-msg", Dict{Any,Any}( :thing1 => "thing1" ))
+    log("info", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69 ))
+    log("warn", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3] ))
+    log("error", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" )))
+    log("crazy", "some-msg", Dict{Any,Any}( :thing1 => "thing1", :thing2 => 69, :thing3 => [1, 2, 3], :thing4 => Dict{Any,Any}( "a" => "apple" ), :thing5 => :some_symbol ))
+
+
+    # test with kwarg params
+    debug("some-msg"; thing1="thing1")
+    Lumberjack.info("some-msg"; thing1="thing1", thing2=69)
+    Lumberjack.warn("some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3])
+    @test_throws ErrorException Lumberjack.error("some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3], thing4=Dict{Any,Any}("a" => "apple"))
+    log("crazy", "some-msg"; thing1="thing1", thing2=69, thing3=[1, 2, 3], thing4=Dict{Any,Any}("a" => "apple"), thing5=:some_symbol)
+end
 
 
 # -------

--- a/test/test-syslog.jl
+++ b/test/test-syslog.jl
@@ -8,6 +8,7 @@ Lumberjack.add_truck(LumberjackTruck(Syslog(:local0, "julia")))
 # Syslog uses an external call to logger to do its legwork. Because the syslog itself can be
 # essentially anywhere (we might not have permission to read it, and it might not even be on
 # the same machine), we'll just make sure that the external call to logger itself is right.
+# This requires that the call to run to be overwritten has the @mendable macro.
 history = []
 mend(run, command::Cmd -> push!(history, string(command))) do
     for mode in modes


### PR DESCRIPTION
StackTraces has been merged into Base as of 0.5.
Added a check to ensure that prior Julia versions still use external package.
Added `@mendable` macro to run call in `Syslog.jl`, which is required for Mocking.jl as of 0.5. (Mocking is used in the Syslog tests to ensure that the proper calls are being made to logger.)
Removed the default value for the `args` dict in `lumbermill.jl` (the cases where they'd be used are already covered by later methods, which resulting in "method overwritten" warnings).
Added let blocks to the test cases to prevent method overwritten warnings.